### PR TITLE
fix: fixes flutter gen errors

### DIFF
--- a/ui_package/__brick__/{{package_name.snakeCase()}}_ui/pubspec.yaml
+++ b/ui_package/__brick__/{{package_name.snakeCase()}}_ui/pubspec.yaml
@@ -16,9 +16,9 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.0
-  build_runner: ^2.0.3
-  flutter_gen_runner: ^4.1.6
+  flutter_lints: ^2.0.1
+  build_runner: ^2.4.4
+  flutter_gen_runner: ^5.3.1
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
For Flutter v 3.10.0 the ui_package brick asset code generator generates code with deprecated warnings and errors.

Upgrading the dependencies fixed it!